### PR TITLE
Change docker image names and added instructions for installation from tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ NSC3 backend installation guides and scripts for single node server configuratio
 - Team-Bridge specific port (Team-Bridge server): 64660
 - [x] SSL certifications for the service domain. Human readable (PEM) format. A private key file named as privkey.pem. A full chained certification file named as fullchain.pem
 - [x] Server domain name is registered to DNS services. 
-- [x] Access account to NSION container registry is available.
 - [x] Linux account with sudo privileges for operating system.
 - [x] Following 3rd party apps are needed: git, wget and curl. Most of them are by default included as part of a linux basic setup. However please ensure beforehand availability on your local linux setup. 
 
 
-## NSC3 backend installation guidance for single node via public NSION repository:
+## NSC3 backend installation guidance for single node:
 ### Default file system locations:
 
 - NSC3 Installation folder: ```$HOME/nsc3```, However this location is configurable. Instruction are referring for ```$HOME/nsc3``` folder. The subfolder "nsc3" will be created automatically while installation process.
@@ -64,7 +63,7 @@ https://github.com/NSION/nsc3/blob/main/nsc3-monitoring/README.md
 ### NSC3 installation:
 #### Install Docker:
 Please follow the latest installation instructions by Docker community https://docs.docker.com/engine/install/ 
-As example Ubuntu:
+As an example, installation for Ubuntu with access to the internet:
 
 ##### Update the apt package index and install packages to allow apt to use a repository over HTTPS:
 ```
@@ -108,29 +107,54 @@ sudo apt install git
 #### Setup installation folder:
 
 - Copy the SSL cert files privkey.pem and fullchain.pem to your home folder. As this example $HOME 
-- Clone git project from NSION SW repository
+- Clone git project from Modirum Platforms NSC3 repository
 
-#### Gather installation scripts from NSION github:
+#### Gather installation scripts from Modirum Platforms github:
+With access to the internet:
 
     cd $HOME
-    git clone https://github.com/NSION/nsc3.git
+    git clone https://github.com/Modirum-Platforms/nsc3.git
+
+If you don't have access to the internet on the machine that NSC3 will be installed:
+- Download a ZIP of the repository from https://github.com/Modirum-Platforms/nsc3
+- Move the ZIP to the NSC3 machine's $HOME folder
+- Run the following commands:
+
+```
+    cd $HOME
+    mkdir $HOME/nsc3
+    unzip nsc3-main.zip -d $HOME/nsc3
+```
     
 #### Grant execute rights for the installation script:
 
     cd $HOME/nsc3
     chmod u+x nsc3-install.sh
     
-#### Login to NSION docker registry:
+#### Gaining access to the docker images:
+
+Via Docker registry:
 
     cd $HOME/nsc3
     sudo docker login registrynsion.azurecr.io
     
     <Registry crentials will be delivered separately>
+
+Via delivered tar file:
+- Move the delivered tar file to the NSC3 machine's $HOME folder
+- Load the images:
+
+```
+    cd $HOME
+    tar -xvf export_release_<YOUR_RELEASE_NUMBER_HERE>.tar.xz
+    cd $HOME/export
+    ls -1 *.tar | xargs --no-run-if-empty -L 1 docker load -i
+```
         
-#### Install Docker-compose:
+#### Install Docker Compose:
 
 Please follow the latest installation instructions by Docker community https://docs.docker.com/compose/install/.
-As example Ubuntu:
+As an example, installation for Ubuntu with access to the internet:
 
 Remove old docker-compose:
 
@@ -234,10 +258,34 @@ NSC3 Admin documentation: https://www.nsiontec.com/user-guide-webapp-admin/
 
 Download the latest scripts from github:
 
+With internet access:
+
     cd $HOME/nsc3
     chmod u-x *.sh
     git pull -f
-    
+
+Without internet access:
+- Download a ZIP of the repository from https://github.com/Modirum-Platforms/nsc3
+- Move the ZIP to the NSC3 machine's $HOME folder
+- Run the following commands:
+
+```
+    cd $HOME
+    mkdir $HOME/nsc3
+    unzip -o nsc3-main.zip -d $HOME/nsc3
+```
+
+If images were loaded from the delivered tar file, you will be delivered a new tar file with updated images:
+- Move the delivered tar file to the NSC3 machine's $HOME folder
+- Load the images:
+
+```
+    cd $HOME
+    tar -xvf export_release_<YOUR_RELEASE_NUMBER_HERE>.tar.xz
+    cd $HOME/export
+    ls -1 *.tar | xargs --no-run-if-empty -L 1 docker load -i
+```
+
 Grant execute rights for the upgrade script:
 
     chmod u+x nsc3-upgrade.sh
@@ -257,17 +305,17 @@ Note that release tag format is
 Stop NSC3 services:
 
     cd $HOME/nsc3
-    sudo docker-compose down
+    sudo docker compose down
 
 Start NSC3 services:
 
     cd $HOME/nsc3
-    sudo docker-compose up -d  
+    sudo docker compose up -d  
 
 Restart NSC3 container:
 
     cd $HOME/nsc3
-    sudo docker-compose restart [NSC3 container]
+    sudo docker compose restart [NSC3 container]
 
 #### Monitoring NSC3 runtime environment:
 
@@ -310,7 +358,7 @@ If the file space in the Docker root directory is not adequate, you must relocat
 1. Stop NSC3 services:
 ```
 cd $HOME/nsc3
-sudo docker-compose down
+sudo docker compose down
 ```
 2. Stop Docker services:
 ```
@@ -359,7 +407,7 @@ sudo docker-compose up -d
 Try to restart NSC3 services:
 
     cd $HOME/nsc3
-    sudo docker-compose up -d 
+    sudo docker compose up -d 
     
 Check https status: 
 Expected result if ok, "HTTP/2 200"
@@ -435,7 +483,7 @@ cat fullchain.pem | grep "BEGIN" | wc -l
 E.g if you have changed SSL cert files then nsc-gateway-service requires restarting in order to take into use a new cert file.
 
 ```
-sudo docker-compose restart nsc-gateway
+sudo docker compose restart nsc-gateway
 ```
 
 ##### Check TCP IP route from external network to NSC3 https port:

--- a/main-postgres-migration.sh
+++ b/main-postgres-migration.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 
 # Test if image is not local and pull
 pull_image () {

--- a/nsc3-conf-tool.sh
+++ b/nsc3-conf-tool.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 export REDISAI_DEVICE="gpu"
 flag=false
 if [ ${1+"true"} ]; then

--- a/nsc3-install.sh
+++ b/nsc3-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 export DOCKERCOMPOSECOMMAND="docker-compose"
 export MINIOSECRET=$(sudo docker inspect nsc-minio | grep MINIO_ROOT_PASSWORD= | awk '{print $1}' | sed s/MINIO_ROOT_PASSWORD=// | sed -e 's/[""]//g') 2> /dev/null
 

--- a/nsc3-upgrade.sh
+++ b/nsc3-upgrade.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 export DOCKERCOMPOSECOMMAND="docker-compose"
 TIMESTAMP=$(date +%Y%m%d%H%M)
 source ./nsc-host.env
 chmod u+x *.sh
-PREVRELEASE=$(cat $NSCHOME/docker-compose.yml | grep registrynsion.azurecr.io/main-postgres: | cut -d\: -f3) 2> /dev/null
+PREVRELEASE=$(cat $NSCHOME/docker-compose.yml | grep registry.menturagroup.com/nsc3/docker-images/main-postgres: | cut -d\: -f3) 2> /dev/null
 export EXTIP=$(host $PUBLICIP | awk '{print $4}') 2> /dev/null
 export MINIOSECRET=$(sudo docker inspect nsc-minio | grep MINIO_ROOT_PASSWORD= | awk '{print $1}' | sed s/MINIO_ROOT_PASSWORD=// | sed -e 's/[""]//g') 2> /dev/null
 silentmode=false

--- a/team-bridge-install.sh
+++ b/team-bridge-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 TIMESTAMP=$(date +%Y%m%d%H%M)
 silentmode=false
 if [ ${1+"true"} ]; then
@@ -158,7 +158,7 @@ if ! [[ $TBMODE = TCP ]]; then
    fi
 fi
 # Grep release tag value
-NSC3REL=$(cat $NSCHOME/docker-compose.yml | grep registrynsion.azurecr.io/main-postgres: | cut -d\: -f3)
+NSC3REL=$(cat $NSCHOME/docker-compose.yml | grep registry.menturagroup.com/nsc3/docker-images/main-postgres: | cut -d\: -f3)
 echo "*** Current release tag: $NSC3REL  ***" 
 RELEASETAG=$NSC3REL
 # Update env variables

--- a/team-bridge.md
+++ b/team-bridge.md
@@ -23,7 +23,7 @@ Pre-requisites for installation:
 
 Bi-Directional pipe combines both elements client and server that need to installed at both end. Dataflow point of view it is similar as in case of One-Directional link but along two pipes outbound and inbound directions. 
 
-In order to get this concept working accordingly, Bi-Directional pipe requires two organizations that need to be created on both servers. Inside of NSC3 server those two independent organisations can be link together by JontOps tasks. Note that Joint Operations functionality in NSC3 requires dedicated license.
+In order to get this concept working accordingly, Bi-Directional pipe requires two organizations that need to be created on both servers. Inside of NSC3 server those two independent organisations can be link together by JointOps tasks. Note that Joint Operations functionality in NSC3 requires dedicated license.
 
 Pre-requisites for installation:
 - 2 x NSC3 servers installed

--- a/valor-docker-compose-ext-reg.tmpl
+++ b/valor-docker-compose-ext-reg.tmpl
@@ -524,7 +524,7 @@ services:
         - analytics-bus-volume:/data:rw
   nsc-analytics-cookbook:
     container_name: nsc-analytics-cookbook
-    image: registrynsion.azurecr.io/nsc-analytics-cookbook:$NSC3REL
+    image: registry.menturagroup.com/nsc3/docker-images/nsc-analytics-cookbook:$NSC3REL
     networks:
         nsc-network:
             ipv4_address: "172.18.0.24"
@@ -580,7 +580,7 @@ services:
         - analytics-bus-volume:/data:rw
   nsc-analytics-cookbook:
     container_name: nsc-analytics-cookbook
-    image: registrynsion.azurecr.io/nsc-analytics-cookbook:$NSC3REL
+    image: registry.menturagroup.com/nsc3/docker-images/nsc-analytics-cookbook:$NSC3REL
     networks:
         nsc-network:
             ipv4_address: "172.18.0.24"
@@ -636,7 +636,7 @@ services:
         - analytics-bus-volume:/data:rw
   nsc-analytics-cookbook:
     container_name: nsc-analytics-cookbook
-    image: registrynsion.azurecr.io/nsc-analytics-cookbook:$NSC3REL
+    image: registry.menturagroup.com/nsc3/docker-images/nsc-analytics-cookbook:$NSC3REL
     networks:
         nsc-network:
             ipv4_address: "172.18.0.24"
@@ -692,7 +692,7 @@ services:
         - analytics-bus-volume:/data:rw
   nsc-analytics-cookbook:
     container_name: nsc-analytics-cookbook
-    image: registrynsion.azurecr.io/nsc-analytics-cookbook:$NSC3REL
+    image: registry.menturagroup.com/nsc3/docker-images/nsc-analytics-cookbook:$NSC3REL
     networks:
         nsc-network:
             ipv4_address: "172.18.0.24"

--- a/valor-install.sh
+++ b/valor-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 export REDISAI_DEVICE="gpu"
 source ./nsc-host.env
 silentmode=false

--- a/valor-installation-guide.md
+++ b/valor-installation-guide.md
@@ -275,12 +275,12 @@ Note that release tag format is
 Stop Valor services:
 
     cd $HOME/nsc3
-    sudo docker-compose -f docker-compose-valor.yml  down
+    sudo docker compose -f docker-compose-valor.yml  down
 
 Start NSC3 services:
 
     cd $HOME/nsc3
-    sudo docker-compose -f docker-compose-valor.yml up -d  
+    sudo docker compose -f docker-compose-valor.yml up -d  
 
 Monitor container logs via docker logs:
 
@@ -306,7 +306,7 @@ Container status:
 Try to restart Valor services:
 
     cd $HOME/nsc3
-    sudo docker-compose -f docker-compose-valor.yml up -d 
+    sudo docker compose -f docker-compose-valor.yml up -d 
     
 Check https status: 
 Expected result if ok, "HTTP/2 200"

--- a/valor-installation-guide.md
+++ b/valor-installation-guide.md
@@ -378,7 +378,7 @@ Note the tag that image gets when loaded
     - Use the tag that image got when loaded; here as an example :release-3.15 . Use actual path in volume mount parameter (-v)
 
 ```
-sudo docker run -d -v /home/exampleuser/demodata/faces:/data/wanted_faces --net nsc-network --restart unless-stopped --name nsc-recipe-face-comparison-service registrynsion.azurecr.io/nsc-recipe-face-comparison-service:release-3.15
+sudo docker run -d -v /home/exampleuser/demodata/faces:/data/wanted_faces --net nsc-network --restart unless-stopped --name nsc-recipe-face-comparison-service registry.menturagroup.com/nsc3/docker-images/nsc-recipe-face-comparison-service:release-3.15
 ```
 
 #### Object detection
@@ -399,10 +399,10 @@ Note the tags that images get when loaded.
 Use the tag that images got when loaded; here as an example :release-3.15
 
 ```
-sudo docker run -d --net nsc-network -e "NVIDIA_VISIBLE_DEVICES=all" -e "NVIDIA_DRIVER_CAPABILITIES=all" --runtime=nvidia --restart unless-stopped --name nsc-recipe-object-detection-service-onnx registrynsion.azurecr.io/nsc-recipe-object-detection-service-onnx:release-3.15
+sudo docker run -d --net nsc-network -e "NVIDIA_VISIBLE_DEVICES=all" -e "NVIDIA_DRIVER_CAPABILITIES=all" --runtime=nvidia --restart unless-stopped --name nsc-recipe-object-detection-service-onnx registry.menturagroup.com/nsc3/docker-images/nsc-recipe-object-detection-service-onnx:release-3.15
 ```
 
 ```
-sudo docker run -d --net nsc-network --restart unless-stopped --name nsc-recipe-object-detection-service registrynsion.azurecr.io/nsc-recipe-object-detection-service:release-3.15
+sudo docker run -d --net nsc-network --restart unless-stopped --name nsc-recipe-object-detection-service registry.menturagroup.com/nsc3/docker-images/nsc-recipe-object-detection-service:release-3.15
 ```
 

--- a/valor-upgrade.sh
+++ b/valor-upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## NSC3 registry:
-export NSC3REG="registrynsion.azurecr.io"
+export NSC3REG="registry.menturagroup.com/nsc3/docker-images"
 source ./nsc-host.env
 silentmode=false
 if [ ${1+"true"} ]; then


### PR DESCRIPTION
- Changed to use modirum platforms image names
- Added instructions for installing NSC3 from tar and without internet
- Fixed some general typos in the instructions